### PR TITLE
Fix notification side effects and email verification autorun

### DIFF
--- a/apps/meteor/app/lib/server/functions/sendMessage.ts
+++ b/apps/meteor/app/lib/server/functions/sendMessage.ts
@@ -195,12 +195,15 @@ export function prepareMessageObject(
 		delete message.tshow;
 	}
 
-	const { _id, username, name } = user;
-	message.u = {
-		_id,
-		username: username as string, // FIXME: this is wrong but I don't want to change it now
-		name,
-	};
+        const { _id, username, name } = user;
+        const normalizedUsername = typeof username === 'string' ? username : '';
+        const normalizedName = typeof name === 'string' ? name : undefined;
+
+        message.u = {
+                _id,
+                username: normalizedUsername,
+                name: normalizedName,
+        };
 	message.rid = rid;
 
 	if (!Match.test(message.msg, String)) {

--- a/apps/meteor/app/lib/server/functions/sendMessage.ts
+++ b/apps/meteor/app/lib/server/functions/sendMessage.ts
@@ -195,15 +195,15 @@ export function prepareMessageObject(
 		delete message.tshow;
 	}
 
-        const { _id, username, name } = user;
-        const normalizedUsername = typeof username === 'string' ? username : '';
-        const normalizedName = typeof name === 'string' ? name : undefined;
+	const { _id, username, name } = user;
+	const normalizedUsername = typeof username === 'string' ? username : '';
+	const normalizedName = typeof name === 'string' ? name : undefined;
 
-        message.u = {
-                _id,
-                username: normalizedUsername,
-                name: normalizedName,
-        };
+	message.u = {
+		_id,
+		username: normalizedUsername,
+		name: normalizedName,
+	};
 	message.rid = rid;
 
 	if (!Match.test(message.msg, String)) {

--- a/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
@@ -182,16 +182,25 @@ export const sendNotification = async ({
 			isThread,
 		})
 	) {
-		const messageWithUnicode = message.msg ? emojione.shortnameToUnicode(message.msg) : message.msg;
-		const firstAttachment = message.attachments?.length && message.attachments.shift();
+                const messageWithUnicode = message.msg ? emojione.shortnameToUnicode(message.msg) : message.msg;
+                const messageAttachments = message.attachments ?? [];
+                const [rawFirstAttachment, ...remainingAttachments] = messageAttachments;
 
-		if (firstAttachment) {
-			firstAttachment.description =
-				typeof firstAttachment.description === 'string' ? emojione.shortnameToUnicode(firstAttachment.description) : undefined;
-			firstAttachment.text = typeof firstAttachment.text === 'string' ? emojione.shortnameToUnicode(firstAttachment.text) : undefined;
-		}
+                const firstAttachment = rawFirstAttachment
+                        ? {
+                                        ...rawFirstAttachment,
+                                        description:
+                                                typeof rawFirstAttachment.description === 'string'
+                                                        ? emojione.shortnameToUnicode(rawFirstAttachment.description)
+                                                        : undefined,
+                                        text:
+                                                typeof rawFirstAttachment.text === 'string'
+                                                        ? emojione.shortnameToUnicode(rawFirstAttachment.text)
+                                                        : undefined,
+                                }
+                        : undefined;
 
-		const attachments = firstAttachment ? [firstAttachment, ...(message.attachments ?? [])].filter(Boolean) : [];
+                const attachments = (firstAttachment ? [firstAttachment, ...remainingAttachments] : [...remainingAttachments]).filter(Boolean);
 		for await (const email of receiver.emails) {
 			if (email.verified) {
 				queueItems.push({

--- a/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
@@ -182,25 +182,20 @@ export const sendNotification = async ({
 			isThread,
 		})
 	) {
-                const messageWithUnicode = message.msg ? emojione.shortnameToUnicode(message.msg) : message.msg;
-                const messageAttachments = message.attachments ?? [];
-                const [rawFirstAttachment, ...remainingAttachments] = messageAttachments;
+		const messageWithUnicode = message.msg ? emojione.shortnameToUnicode(message.msg) : message.msg;
+		const messageAttachments = message.attachments ?? [];
+		const [rawFirstAttachment, ...remainingAttachments] = messageAttachments;
 
-                const firstAttachment = rawFirstAttachment
-                        ? {
-                                        ...rawFirstAttachment,
-                                        description:
-                                                typeof rawFirstAttachment.description === 'string'
-                                                        ? emojione.shortnameToUnicode(rawFirstAttachment.description)
-                                                        : undefined,
-                                        text:
-                                                typeof rawFirstAttachment.text === 'string'
-                                                        ? emojione.shortnameToUnicode(rawFirstAttachment.text)
-                                                        : undefined,
-                                }
-                        : undefined;
+		const firstAttachment = rawFirstAttachment
+			? {
+					...rawFirstAttachment,
+					description:
+						typeof rawFirstAttachment.description === 'string' ? emojione.shortnameToUnicode(rawFirstAttachment.description) : undefined,
+					text: typeof rawFirstAttachment.text === 'string' ? emojione.shortnameToUnicode(rawFirstAttachment.text) : undefined,
+				}
+			: undefined;
 
-                const attachments = (firstAttachment ? [firstAttachment, ...remainingAttachments] : [...remainingAttachments]).filter(Boolean);
+		const attachments = (firstAttachment ? [firstAttachment, ...remainingAttachments] : [...remainingAttachments]).filter(Boolean);
 		for await (const email of receiver.emails) {
 			if (email.verified) {
 				queueItems.push({

--- a/apps/meteor/client/serviceWorker.ts
+++ b/apps/meteor/client/serviceWorker.ts
@@ -1,8 +1,25 @@
 const KEY = 'sw_last_reload';
 const RELOAD_WINDOW = 1000 * 10;
 
+function safeLocalStorageGet(key: string) {
+        try {
+                return localStorage.getItem(key);
+        } catch (error) {
+                console.warn('service worker: unable to access localStorage', error);
+                return null;
+        }
+}
+
+function safeLocalStorageSet(key: string, value: string) {
+        try {
+                localStorage.setItem(key, value);
+        } catch (error) {
+                console.warn('service worker: unable to persist service worker reload marker', error);
+        }
+}
+
 function reload() {
-	const lastReload = localStorage.getItem(KEY);
+        const lastReload = safeLocalStorageGet(KEY);
 
 	if (lastReload) {
 		const last = Date.parse(lastReload);
@@ -16,9 +33,9 @@ function reload() {
 		}
 	}
 
-	localStorage.setItem(KEY, new Date().toISOString());
-	console.log('service worker: reloading to activate');
-	window.location.reload();
+        safeLocalStorageSet(KEY, new Date().toISOString());
+        console.log('service worker: reloading to activate');
+        window.location.reload();
 }
 
 if ('serviceWorker' in navigator) {

--- a/apps/meteor/client/serviceWorker.ts
+++ b/apps/meteor/client/serviceWorker.ts
@@ -2,24 +2,24 @@ const KEY = 'sw_last_reload';
 const RELOAD_WINDOW = 1000 * 10;
 
 function safeLocalStorageGet(key: string) {
-        try {
-                return localStorage.getItem(key);
-        } catch (error) {
-                console.warn('service worker: unable to access localStorage', error);
-                return null;
-        }
+	try {
+		return localStorage.getItem(key);
+	} catch (error) {
+		console.warn('service worker: unable to access localStorage', error);
+		return null;
+	}
 }
 
 function safeLocalStorageSet(key: string, value: string) {
-        try {
-                localStorage.setItem(key, value);
-        } catch (error) {
-                console.warn('service worker: unable to persist service worker reload marker', error);
-        }
+	try {
+		localStorage.setItem(key, value);
+	} catch (error) {
+		console.warn('service worker: unable to persist service worker reload marker', error);
+	}
 }
 
 function reload() {
-        const lastReload = safeLocalStorageGet(KEY);
+	const lastReload = safeLocalStorageGet(KEY);
 
 	if (lastReload) {
 		const last = Date.parse(lastReload);
@@ -33,9 +33,9 @@ function reload() {
 		}
 	}
 
-        safeLocalStorageSet(KEY, new Date().toISOString());
-        console.log('service worker: reloading to activate');
-        window.location.reload();
+	safeLocalStorageSet(KEY, new Date().toISOString());
+	console.log('service worker: reloading to activate');
+	window.location.reload();
 }
 
 if ('serviceWorker' in navigator) {

--- a/apps/meteor/client/startup/accounts.ts
+++ b/apps/meteor/client/startup/accounts.ts
@@ -19,19 +19,23 @@ const watchMainReady = () => {
 };
 
 Accounts.onEmailVerificationLink((token: string) => {
-	Accounts.verifyEmail(token, (error) => {
-		Tracker.autorun(() => {
-			if (!watchMainReady()) return;
+        Accounts.verifyEmail(token, (error) => {
+                Tracker.autorun((c) => {
+                        if (!watchMainReady()) {
+                                return;
+                        }
 
-			if (error) {
-				dispatchToastMessage({ type: 'error', message: error });
-				throw new Meteor.Error('verify-email', 'E-mail not verified');
-			} else {
-				Tracker.nonreactive(() => {
-					void sdk.call('afterVerifyEmail');
-				});
-				dispatchToastMessage({ type: 'success', message: t('Email_verified') });
-			}
-		});
-	});
+                        c.stop();
+
+                        if (error) {
+                                dispatchToastMessage({ type: 'error', message: error });
+                                throw new Meteor.Error('verify-email', 'E-mail not verified');
+                        }
+
+                        Tracker.nonreactive(() => {
+                                void sdk.call('afterVerifyEmail');
+                        });
+                        dispatchToastMessage({ type: 'success', message: t('Email_verified') });
+                });
+        });
 });

--- a/apps/meteor/client/startup/accounts.ts
+++ b/apps/meteor/client/startup/accounts.ts
@@ -19,23 +19,23 @@ const watchMainReady = () => {
 };
 
 Accounts.onEmailVerificationLink((token: string) => {
-        Accounts.verifyEmail(token, (error) => {
-                Tracker.autorun((c) => {
-                        if (!watchMainReady()) {
-                                return;
-                        }
+	Accounts.verifyEmail(token, (error) => {
+		Tracker.autorun((c) => {
+			if (!watchMainReady()) {
+				return;
+			}
 
-                        c.stop();
+			c.stop();
 
-                        if (error) {
-                                dispatchToastMessage({ type: 'error', message: error });
-                                throw new Meteor.Error('verify-email', 'E-mail not verified');
-                        }
+			if (error) {
+				dispatchToastMessage({ type: 'error', message: error });
+				throw new Meteor.Error('verify-email', 'E-mail not verified');
+			}
 
-                        Tracker.nonreactive(() => {
-                                void sdk.call('afterVerifyEmail');
-                        });
-                        dispatchToastMessage({ type: 'success', message: t('Email_verified') });
-                });
-        });
+			Tracker.nonreactive(() => {
+				void sdk.call('afterVerifyEmail');
+			});
+			dispatchToastMessage({ type: 'success', message: t('Email_verified') });
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- avoid mutating message attachments when preparing email notifications
- stop the email verification autorun once the data stores are ready and handle service worker storage failures
- normalise message sender metadata to prevent undefined usernames from being stored

## Testing
- `YARN_IGNORE_NODE=1 yarn workspace @rocket.chat/meteor eslint -- apps/meteor/client/startup/accounts.ts apps/meteor/client/serviceWorker.ts apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts apps/meteor/app/lib/server/functions/sendMessage.ts` *(fails: The current Node version v22.19.0 does not satisfy the required version 22.16.0.)*

------
https://chatgpt.com/codex/tasks/task_e_68d1063f45ac8331ac132c2b9e18637a